### PR TITLE
Fix scheduler initialization.

### DIFF
--- a/botshot/apps.py
+++ b/botshot/apps.py
@@ -6,6 +6,7 @@ class BotshotConfig(AppConfig):
 
     def ready(self):
         from botshot.core.interface_factory import InterfaceFactory
+        import botshot.core.scheduler  # loads periodic scheduler task
         interfaces = InterfaceFactory().get_interfaces()
         for itf in interfaces:
             itf().on_server_startup()


### PR DESCRIPTION
Added missing import in `apps.py`.

Idea: We could make a function like `init_scheduler` that would use a different "backend" if someone wants to just use django without celery for testing. I think that scheduler is one of the few things that block this.